### PR TITLE
Switch to self-hosted runner for Maven build

### DIFF
--- a/.github/workflows/mavenLinux.yml
+++ b/.github/workflows/mavenLinux.yml
@@ -16,9 +16,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17


### PR DESCRIPTION
Updated the GitHub Actions workflow to use a self-hosted runner instead of the default `ubuntu-latest`. This change aims to improve build performance and resource management.